### PR TITLE
Add search files and folders function by recursion

### DIFF
--- a/projects/ngx-filemanager-client-firebase/src/lib/configuration/client-configuration.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/configuration/client-configuration.ts
@@ -22,4 +22,6 @@ export interface FileManagerConfig {
 
   showWriters?: boolean;
   showOthers?: boolean;
+
+  enableSearch?: boolean;
 }

--- a/projects/ngx-filemanager-client-firebase/src/lib/ngx-filemanager-client-firebase.module.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ngx-filemanager-client-firebase.module.ts
@@ -43,6 +43,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatExpansionModule } from '@angular/material/expansion';
 
 const declarations = [
   LibMainFileManagerComponent,
@@ -86,7 +87,8 @@ const declarations = [
     MatTableModule,
     MatTabsModule,
     MatToolbarModule,
-    MatTooltipModule
+    MatTooltipModule,
+    MatExpansionModule
   ],
   exports: [LibMainFileManagerComponent],
   providers: [

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/action-handlers.service.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/action-handlers.service.ts
@@ -332,4 +332,9 @@ export class ActionHandlersService {
     await cloned.init(this.fileSystem, this.config);
     return cloned;
   }
+
+  //Search 
+  public ListCurrentPathItems(path: string): Promise<CoreTypes.ResBodyList> {
+    return this.fileSystem.List(path);
+  }
 }

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.html
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.html
@@ -51,6 +51,94 @@
           </div>
         </div>
       </div>
+      <div *ngIf="enableSearch">
+        <form (submit)="searchAllDocumentsAndFolders(searchKeyword)" [formGroup]="searchForm">
+          <mat-form-field class="w-full px-2">
+            <input matInput [(ngModel)]="searchKeyword" formControlName="searchKeyword" placeholder="Search here"/>
+          </mat-form-field>
+          <mat-progress-spinner
+              *ngIf="showSearchingSpinner"
+              mode="determinate"
+              [diameter]="40"
+              color="warn"
+              [value]="100"
+            ></mat-progress-spinner>
+        </form>
+        <div *ngIf="!showSearchingSpinner&&isSearching&&seachResultDocuments.length===0&&seachResultFolders.length===0">
+          <div class="card-container">
+            <h4>Search results: </h4>
+            <mat-card >
+              <div class="document">
+                <div class="title">
+                  There are no site files/folders match your keyword.
+                </div>
+              </div>
+            </mat-card>
+          </div>
+        </div>
+        <div class="exp-panel" *ngIf="seachResultDocuments.length>0">
+          <mat-expansion-panel [expanded]="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                Files:
+              </mat-panel-title>
+              <mat-panel-description>
+                They are results of search files.
+              </mat-panel-description>
+            </mat-expansion-panel-header>
+            <mat-card (click)="onSelectedSearchItem(document)" *ngFor="let document of seachResultDocuments|slice:0: documentsShow">
+              <div class="document">
+                <div class="title">
+                  {{document.name}}
+                </div>
+                <div class="search-item">
+                  <mat-icon class="icon-size-44 text-primary">
+                      insert_drive_file
+                  </mat-icon>
+                  <span>{{ document.fullPath }}</span>
+              </div>
+              </div>
+            </mat-card>
+            <div class="text-right">
+              <button 
+                *ngIf="documentsShow < seachResultDocuments.length"
+                (click)="documentsShow=documentsShow+10"
+                mat-raised-button>Load more</button>
+              </div>
+          </mat-expansion-panel>
+        </div>
+        <div class="exp-panel" *ngIf="seachResultFolders.length>0">
+          <mat-expansion-panel [expanded]="true">
+            <mat-expansion-panel-header>
+              <mat-panel-title>
+                Folders:
+              </mat-panel-title>
+              <mat-panel-description>
+                They are results of search folders.
+              </mat-panel-description>
+            </mat-expansion-panel-header>
+            <mat-card (click)="onSelectedSearchItem(folder)" *ngFor="let folder of seachResultFolders|slice:0: foldersShow">
+              <div class="document">
+                <div class="title">
+                  {{folder.name}}
+                </div>
+                <div class="search-item">
+                  <mat-icon class="icon-size-44 text-primary">
+                      folder
+                  </mat-icon>
+                  <span>{{ folder.fullPath }}</span>
+                </div>
+              </div>
+            </mat-card>
+            <div class="text-right">
+              <button 
+                *ngIf="foldersShow < seachResultFolders.length"
+                (click)="foldersShow=foldersShow+10"
+                mat-raised-button>Load more</button>
+            </div>
+          </mat-expansion-panel>
+        </div>
+      </div>
       <app-file-table
         *ngIf="folders$ && files$"
         [folders]="folders$ | async"

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.scss
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.scss
@@ -68,3 +68,11 @@ button.top {
 .breadcrumb-container {
   margin: 2px 0px;
 }
+
+.document {
+  cursor: pointer;
+}
+.search-item {
+  display: flex;
+  align-items: center;
+}

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.ts
@@ -13,6 +13,7 @@ import { FileActionDefinition } from '../file-table/FileActionDefinition';
 import { BulkActionDefinition } from '../actions-toolbars/BulkActionDefinition';
 import { MainActionDefinition } from '../actions-toolbars/MainActionDefinition';
 import { FileDetailActionDefinition } from '../file-details/FileDetailActionDefinition';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -24,6 +25,7 @@ import { FileDetailActionDefinition } from '../file-details/FileDetailActionDefi
     ClientFileSystemService,
     OptimisticFilesystemService
   ]
+  
 })
 export class LibMainFileManagerComponent implements OnInit, OnDestroy {
   @Input()
@@ -54,12 +56,25 @@ export class LibMainFileManagerComponent implements OnInit, OnDestroy {
   folders$: Observable<CoreTypes.ResFile[]>;
   files$: Observable<CoreTypes.ResFile[]>;
 
+  enableSearch: boolean = false;
+  searchForm: FormGroup;
+  searchKeyword: string = '';
+  seachResultDocuments: CoreTypes.ResFile[] = [];
+  seachResultFolders: CoreTypes.ResFile[] = [];
+  documentsShow: number = 10;
+  foldersShow: number = 10;
+  isSearching: boolean = false;
+  showSearchingSpinner: boolean = false;
+
   constructor(
     private actionHandlers: ActionHandlersService,
     private logger: LoggerService,
-    private status: FilemanagerStatusService
+    private status: FilemanagerStatusService,
   ) {
     this.requestMap = this.status.ActiveRequestsMap;
+    this.searchForm = new FormGroup({
+      searchKeyword: new FormControl('', [Validators.minLength(3)]),
+    });
   }
 
   // Getters
@@ -126,6 +141,7 @@ export class LibMainFileManagerComponent implements OnInit, OnDestroy {
       .subscribe();
     this.makeConfig();
     this.initLoaded = true;
+    this.enableSearch = !!this.config.enableSearch || false;
   }
 
   ngOnDestroy() {
@@ -349,5 +365,75 @@ export class LibMainFileManagerComponent implements OnInit, OnDestroy {
   public ClearBulkSelected() {
     this.$triggerClearSelected.next();
     this.$BulkSelected.next([]);
+  }
+
+  // Search
+  public async searchAllDocumentsAndFolders(keyword: string) {
+    keyword = keyword.toLocaleLowerCase().trim();
+    if(!this.searchForm.valid){ 
+      return
+    };
+    await this.initCleanSearchResults();
+    const startPath = this.actionHandlers.GetRootPath();
+    this.isSearching = true;
+    this.showSearchingSpinner = true;
+    this.iterateCurrentDocumentAndFolders(startPath, keyword, 0);
+  }
+
+  private async iterateCurrentDocumentAndFolders(currentPath: string, keyword: string, level: number) {
+      if(level > 100) {
+        this.isSearching = false;
+      }
+      if(this.showSearchingSpinner) {
+        this.showSearchingSpinner = (this.isSearching&&this.seachResultDocuments.length===0&&this.seachResultFolders.length===0&&level < 3);
+      }
+      if(!this.isSearching) {
+        return
+      }
+
+      const currentVisiableDocuments: CoreTypes.ResFile[] = (await this.actionHandlers.ListCurrentPathItems(currentPath)).result;
+      currentVisiableDocuments.forEach((item: CoreTypes.ResFile)=>{
+        console.log('I am file', item, 'item.type', item.type)
+        if(item.type==='file') {
+          if(this.checkSearchKeywordRelative(item.name, keyword)) {
+            console.log('pushed inside dir')
+            this.seachResultDocuments.push(item);
+          }
+        } else if(item.type==='dir') {
+          if(this.checkSearchKeywordRelative(item.name, keyword)) {
+            console.log('pushed inside dir');
+            this.seachResultFolders.push(item);
+          }
+          this.iterateCurrentDocumentAndFolders(item.fullPath, keyword, level+1);
+        }
+      });
+  }
+
+  public checkSearchKeywordRelative(targetName: string, keyword: string) {
+    return targetName.toLowerCase().includes(keyword);
+  }
+
+  public initCleanSearchResults() {
+    this.isSearching = false;
+    this.showSearchingSpinner = false;
+    return new Promise<void>((resolve)=>{
+      setTimeout(() => {
+        this.seachResultDocuments = [];
+        this.seachResultFolders = [];
+        this.foldersShow = 5;
+        this.documentsShow = 5;
+        resolve();
+      }, 10);
+    })
+  }
+
+  public onSelectedSearchItem(item: CoreTypes.ResFile) {
+    //this.initCleanSearchResults();
+    if(item.type === 'file') {
+      let fileParentPath = item.fullPath.substring(0, item.fullPath.lastIndexOf('/'));
+      this.onEnterFolder(fileParentPath);
+    } else if (item.type === 'dir') {
+      this.onEnterFolder(item.fullPath);
+    }
   }
 }

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.ts
@@ -393,15 +393,13 @@ export class LibMainFileManagerComponent implements OnInit, OnDestroy {
 
       const currentVisiableDocuments: CoreTypes.ResFile[] = (await this.actionHandlers.ListCurrentPathItems(currentPath)).result;
       currentVisiableDocuments.forEach((item: CoreTypes.ResFile)=>{
-        console.log('I am file', item, 'item.type', item.type)
+        console.log( item, 'item.type', item.type)
         if(item.type==='file') {
           if(this.checkSearchKeywordRelative(item.name, keyword)) {
-            console.log('pushed inside dir')
             this.seachResultDocuments.push(item);
           }
         } else if(item.type==='dir') {
           if(this.checkSearchKeywordRelative(item.name, keyword)) {
-            console.log('pushed inside dir');
             this.seachResultFolders.push(item);
           }
           this.iterateCurrentDocumentAndFolders(item.fullPath, keyword, level+1);


### PR DESCRIPTION
Add file and folder search by keyword implemented by recursion so it will loop through not greater than 100-depth folders on the client-side.

Once there is a result found, it will be added to the expand-panel list. Click one of the results, Filemanger will take you to its path if it is a folder, Filemanager will take you to the path where it is if it is a file. 