### PR TITLE
Add folder size feature

### DIFF
--- a/projects/ngx-filemanager-client-firebase-demo/src/app/test-functions-remote.component.ts
+++ b/projects/ngx-filemanager-client-firebase-demo/src/app/test-functions-remote.component.ts
@@ -61,6 +61,14 @@ import { environment } from '../environments/environment';
         <p>Enable Search? ({{ hasSearchControl.value ? 'Yes' : 'No' }})</p>
         <mat-slide-toggle [formControl]="hasSearchControl"> </mat-slide-toggle>
       </div>
+      <mat-form-field style="margin-left: 15px;">
+        <input
+          matInput
+          placeholder="folderSizePath"
+          type="text"
+          [formControl]="folderSizePath"
+        />
+      </mat-form-field>
       </div>
     </mat-card>
 
@@ -80,7 +88,8 @@ export class AppTestFunctionsRemoteComponent implements OnDestroy {
     users: $users,
     groups: $groups,
     firebaseConfig: environment.firebaseConfig,
-    bucketName: ''
+    bucketName: '',
+    folderSizePath: ''
   };
 
   bucketName = new FormControl();
@@ -89,6 +98,7 @@ export class AppTestFunctionsRemoteComponent implements OnDestroy {
   firebaseConfig = new FormControl();
   isAdminControl = new FormControl();
   hasSearchControl = new FormControl();
+  folderSizePath = new FormControl();
 
   showExplorer = false;
 
@@ -117,7 +127,8 @@ export class AppTestFunctionsRemoteComponent implements OnDestroy {
         distinctUntilChanged()
       ),
       this.isAdminControl.valueChanges,
-      this.hasSearchControl.valueChanges
+      this.hasSearchControl.valueChanges,
+      this.folderSizePath.valueChanges
     ])
       .pipe(debounceTime(500), takeUntil(this.destroyed))
       .subscribe(() => this.reInitializeExplorer());
@@ -136,6 +147,7 @@ export class AppTestFunctionsRemoteComponent implements OnDestroy {
     this.firebaseConfig.setValue(localStorage.getItem('firebaseConfig') || '');
     this.isAdminControl.setValue(localStorage.getItem('isAdmin') == 'true' || false);
     this.hasSearchControl.setValue(localStorage.getItem('hasSearch') == 'true' || false);
+    this.folderSizePath.setValue(localStorage.getItem('folderSizePath') || '');
   }
 
   ngOnDestroy() {
@@ -154,12 +166,14 @@ export class AppTestFunctionsRemoteComponent implements OnDestroy {
     this.config.bucketName = this.bucketName.value;
     this.config.isAdmin = this.isAdminControl.value;
     this.config.enableSearch = this.hasSearchControl.value;
+    this.config.folderSizePath = this.folderSizePath.value;
     localStorage.setItem('bucketname', this.bucketName.value);
     localStorage.setItem('apiendpoint', this.apiEndpoint.value);
     localStorage.setItem('virtualRoot', this.virtualRoot.value);
     localStorage.setItem('firebaseConfig', this.firebaseConfig.value);
     localStorage.setItem('isAdmin', this.isAdminControl.value);
     localStorage.setItem('hasSearch', this.hasSearchControl.value);
+    localStorage.setItem('folderSizePath', this.folderSizePath.value);
     setTimeout(() => {
       this.showExplorer = true;
     }, 100);

--- a/projects/ngx-filemanager-client-firebase/src/lib/configuration/client-configuration.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/configuration/client-configuration.ts
@@ -24,4 +24,6 @@ export interface FileManagerConfig {
   showOthers?: boolean;
 
   enableSearch?: boolean;
+
+  folderSizePath?: string
 }

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/file-details/file-details.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/file-details/file-details.component.ts
@@ -40,7 +40,8 @@ import { FileDetailActionDefinition } from './FileDetailActionDefinition';
           </div>
         </span>
         <h5 class="mt-5">Size</h5>
-        <h6>{{ file.size | fileSize }}</h6>
+        <h6 *ngIf="isFile">{{ file.size | fileSize }}</h6>
+        <h6 *ngIf="!isFile&&config.folderSizePath">{{ getFolderSize(file) | fileSize }}</h6>
         <h5 class="mt-5">Date</h5>
         <h6>{{ file.date | date: 'short' }}</h6>
         <span class="flex-row space-between align-top mt-5">
@@ -239,5 +240,13 @@ export class FileDetailsComponent {
         file: this._file
       });
     }
+  }
+
+  getFolderSize(folder: CoreTypes.ResFile) {
+    if(folder.metaData) {
+      let path = this.config.folderSizePath
+      return path.split('.').reduce(function(p,prop) { return p[prop] }, folder);
+    }
+    return folder.size
   }
 }

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/file-table/card-folder.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/file-table/card-folder.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { SelectionModel } from '@angular/cdk/collections';
 import { CoreTypes } from '../../../core-types';
 import { FileActionDefinition } from './FileActionDefinition';
+import { FileManagerConfig } from '../../configuration/client-configuration';
 
 @Component({
   selector: 'card-folder',
@@ -32,7 +33,7 @@ import { FileActionDefinition } from './FileActionDefinition';
         <img class="mr-10" width="30" [src]="folder['icon']" />
         <div>
           <h5 class="m0 mb-5 has-ellipsis">{{ folder.name }}</h5>
-          <small class="m0 color-grey">{{ folder.size | fileSize }}</small>
+          <small *ngIf="config.folderSizePath" class="m0 color-grey">{{ getFolderSize(folder) | fileSize }}</small>
         </div>
       </div>
       <button
@@ -76,6 +77,8 @@ export class CardFolderComponent {
   checkedItems: SelectionModel<string>;
   @Input()
   selectedItem: SelectionModel<string>;
+  @Input()
+  config: FileManagerConfig;
   @Output()
   enterFolder = new EventEmitter<string>();
 
@@ -91,5 +94,13 @@ export class CardFolderComponent {
   onDoubleClick() {
     console.log('onDoubleClick!');
     this.enterFolder.emit(this.folder.fullPath);
+  }
+
+  getFolderSize(folder: CoreTypes.ResFile) {
+    if(folder.metaData) {
+      let path = this.config.folderSizePath
+      return path.split('.').reduce(function(p,prop) { return p[prop] }, folder);
+    }
+    return folder.size
   }
 }

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/file-table/file-table.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/file-table/file-table.component.ts
@@ -11,6 +11,7 @@ import { Subject, Observable } from 'rxjs';
 import { SelectionModel } from '@angular/cdk/collections';
 import { takeUntil } from 'rxjs/operators';
 import { FileActionDefinition } from './FileActionDefinition';
+import { FileManagerConfig } from '../../configuration/client-configuration';
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -36,6 +37,7 @@ import { FileActionDefinition } from './FileActionDefinition';
         <card-folder
           *ngFor="let folder of folders"
           [folder]="folder"
+          [config]="config"
           [checkedItems]="checkedItems"
           [selectedItem]="selectedItem"
           [actions]="folderActions"
@@ -106,6 +108,8 @@ export class AppFileTableComponent implements OnInit, OnDestroy {
   files: CoreTypes.ResFile[];
   @Input()
   folders: CoreTypes.ResFile[];
+  @Input()
+  config: FileManagerConfig;
   @Output()
   checkedChanged = new EventEmitter<CoreTypes.ResFile[]>();
   @Output()

--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.html
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/main-file-manager/main-file-manager.component.html
@@ -145,6 +145,7 @@
         [files]="files$ | async"
         [fileActions]="fileActions"
         [folderActions]="folderActions"
+        [config]="config"
         [$triggerClearSelected]="$triggerClearSelected"
         (checkedChanged)="$BulkSelected.next($event)"
         (selectedChanged)="this.onSelectedFilePath($event)"


### PR DESCRIPTION
Hi Ben,

The original issue here: https://github.com/resvu/communitilink-admin/issues/1144, the folder always shows 0 bytes in UI.

As firebase storage does not provide folder size in metadata, refer to https://stackoverflow.com/questions/38762731/get-storage-space-used-in-a-folder-in-firebase-storage.

So my solution the first step is to hide the size attribute in UI if it is a folder.  

The second step is to read custom meta if users calculate folder size and store it in custom metadata, for example, "metaData.size_children" if they pass this path in config object, and UI is able to show this size.

And I also created test input in demo.

Hope you could merge my PR and have a good day!

Thanks
Wyatt