### PR TITLE
Avoid use push permission to array

### DIFF
--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/tags-control/tags-control.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/tags-control/tags-control.component.ts
@@ -210,7 +210,12 @@ export class AppControlTagMultipleComponent implements OnInit, OnDestroy {
   selectedTag(event: MatAutocompleteSelectedEvent): void {
     console.log(event);
     const newVal = event.option.value;
-    this.control.value.push(newVal);
+    let canPush = true;
+    this.control.value.forEach((item)=>{
+      canPush = (item.id !== newVal.id) && canPush
+    })
+    if(canPush)
+      this.control.value.push(newVal);
     this.tagInput.nativeElement.value = '';
     this.tagInput.nativeElement.blur();
     this.updateFormValue();


### PR DESCRIPTION
Hi Ben,
 Currently, user is able to add permission to permission array with same id, so I add a filter to avoid users push the permission with same permission id. 

Hopefully, this makes sense to you. 

Thank you and have a nice day!

Wyatt


<img width="612" alt="permission-id" src="https://user-images.githubusercontent.com/53634020/120957998-e458a000-c795-11eb-940a-6be117a7392d.png">
