### PR TITLE
Fix config could be undefined, add undefined check safe

### DIFF
--- a/projects/ngx-filemanager-client-firebase/src/lib/ui/file-table/card-folder.component.ts
+++ b/projects/ngx-filemanager-client-firebase/src/lib/ui/file-table/card-folder.component.ts
@@ -33,7 +33,7 @@ import { FileManagerConfig } from '../../configuration/client-configuration';
         <img class="mr-10" width="30" [src]="folder['icon']" />
         <div>
           <h5 class="m0 mb-5 has-ellipsis">{{ folder.name }}</h5>
-          <small *ngIf="config.folderSizePath" class="m0 color-grey">{{ getFolderSize(folder) | fileSize }}</small>
+          <small *ngIf="config && config.folderSizePath" class="m0 color-grey">{{ getFolderSize(folder) | fileSize }}</small>
         </div>
       </div>
       <button


### PR DESCRIPTION
Hi Ben,

We found an issue happened in move file/folder. After I investigated, I found this is because there is no config variable in <app-file-table-mini-folder-browser /> so it tries to access property of undefined. Therefore I added undefined check safe for this component. 

Hope this makes sense to you.

Thanks
Wyatt


<img width="704" alt="Screen Shot 2021-07-16 at 1 11 14 pm" src="https://user-images.githubusercontent.com/53634020/125888632-bc7ed55e-6964-482b-9eed-d2be95f10a97.png">

![Screen Shot 2021-07-16 at 1 11 21 pm](https://user-images.githubusercontent.com/53634020/125888623-de62edcf-9f6b-4746-bef4-26d167a9a315.png)